### PR TITLE
HOTFIX parameter name in `updatePreviousFraudFlag` method of `Account…

### DIFF
--- a/src/main/java/com/modernbank/transaction_service/api/client/AccountServiceClient.java
+++ b/src/main/java/com/modernbank/transaction_service/api/client/AccountServiceClient.java
@@ -55,6 +55,6 @@ public interface AccountServiceClient {
         @PostMapping(path = "${feign.client.account-service.updatePreviousFraudFlag}")
         BaseResponse updatePreviousFraudFlag(
                         @RequestParam(value = "accountId") String accountId,
-                        @RequestParam(value = "flag") Boolean flag);
+                        @RequestParam(value = "isFraud") Boolean flag);
 
 }


### PR DESCRIPTION
…ServiceClient`:

- Rename `flag` to `isFraud` for clarity and consistency with parameter purpose.